### PR TITLE
Fix OKX WebSocket URL

### DIFF
--- a/eth_gui_project/ethgui/config.py
+++ b/eth_gui_project/ethgui/config.py
@@ -18,5 +18,6 @@ DEFAULT_MIN_HITS = 2
 
 # ---- OKX 接口地址 ----
 OKX_REST_URL = "https://www.okx.com/api/v5/market/candles"
-WS_URL       = "wss://ws.okx.com:8443/ws/v5/public"
+# WebSocket 市场行情地址根据官方文档应使用 /ws/v5/market
+WS_URL       = "wss://ws.okx.com:8443/ws/v5/market"
 WS_PROXY = "http://127.0.0.1:7890"


### PR DESCRIPTION
## Summary
- point WebSocket endpoint to `ws/v5/market` per OKX documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python eth_gui_project/ethgui/main.py` *(fails: libEGL.so.1 missing)*
- `python - <<'EOF' ...` *(fails: proxy rejected connection)*

------
https://chatgpt.com/codex/tasks/task_e_6866d81fec3c8326998f7ec74efc3e16